### PR TITLE
change the `serving2`'s port mapping to run

### DIFF
--- a/step6-load-balancer/docker-compose.yml
+++ b/step6-load-balancer/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: node:11.12
     hostname: serving2
     ports:
-      - "3000:3000"
+      - "3001:3000"
     volumes:
       - ./serving.js:/bin/serving.js
     command: bash -c "node /bin/serving.js"


### PR DESCRIPTION
I have to change the `serving2` service's port mapping to `3001:3000` to run, otherwise when `docker-compose up`, the terminal prompt

```
ERROR: for serving2  Cannot start service serving2: driver failed programming external connectivity on endpoint nginx-load-balance_serving2_1 (5787df66f7d6a9591b40a6a0b4ae25e71ba3e0c0913b66dc86645854ed2238c2): Bind for 0.0.0.0:3000 failed: port is already allocated
```

Is there anything I missed when I went through your article?